### PR TITLE
Update to Manifest V3

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,20 +1,20 @@
-chrome.runtime.onInstalled.addListener(function () {
+chrome.runtime.onInstalled.addListener(() => {
     chrome.storage.local.set({
-            mvtRequestPattern: ".*\\/(?<z>\\d+)\\/(?<x>\\d+)\\/(?<y>\\d+)\\.mvt[^\\/]*$",
-            trackEmptyResponse: true,
-            trackOnlySuccessfulResponse: false
-        },
-        function () {
-        }
-    );
+        mvtRequestPattern: ".*\\/(?<z>\\d+)\\/(?<x>\\d+)\\/(?<y>\\d+)\\.mvt[^\\/]*$",
+        trackEmptyResponse: true,
+        trackOnlySuccessfulResponse: false
+    });
 
-    chrome.declarativeContent.onPageChanged.removeRules(undefined, function () {
-        chrome.declarativeContent.onPageChanged.addRules([{
-            conditions: [new chrome.declarativeContent.PageStateMatcher({
-                pageUrl: {},
-            })
-            ],
-            actions: [new chrome.declarativeContent.ShowPageAction()]
-        }]);
+    chrome.declarativeContent.onPageChanged.removeRules(undefined, () => {
+        chrome.declarativeContent.onPageChanged.addRules([
+            {
+                conditions: [
+                    new chrome.declarativeContent.PageStateMatcher({
+                        pageUrl: {}  // Matches all pages
+                    })
+                ],
+                actions: [new chrome.declarativeContent.ShowAction()]
+            }
+        ]);
     });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -4,11 +4,11 @@
 	"description" : "Parser for loaded Mapbox Vector Tiles",
 	"permissions" : ["declarativeContent", "storage", "activeTab", "tabs"],
 	"background" : {
-		"scripts" : ["background.js"],
-		"persistent" : false
+		"service_worker": "background.js"
 	},
-	"page_action" : {
+	"action" : {
 		"default_popup" : "popup.html",
+		"default_title": "Mapbox Vector Tiles",
 		"default_icon" : {
 			"16" : "images/logo16.png",
 			"32" : "images/logo32.png",
@@ -23,5 +23,5 @@
 		"48" : "images/logo48.png",
 		"128" : "images/logo128.png"
 	},
-	"manifest_version" : 2
+	"manifest_version" : 3
 }


### PR DESCRIPTION
Update this extension to Chrome Extensions' Manifest V3 so it can continue to be loaded in newer versions of Google Chrome.

I attempted to do this quickly while changing as little as possible. I'm happy to take feedback on how this could be better migrated, but it appears to work well for me locally.